### PR TITLE
Create Nuxt 3 markdown template editor with AI chat integration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  root: true,
+  extends: ['eslint:recommended', 'plugin:vue/vue3-recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  rules: {
+    'vue/multi-word-component-names': 'off'
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.nitro
+.nuxt
+.DS_Store
+.env
+*.log
+.lock-wscript

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# chat-to-template
+# Chat-to-Template
+
+A Nuxt 3 application for building Markdown templates that are filled using an AI-powered chat workflow. Users can write Markdown templates with placeholders (e.g. `{{placeholder}}`), converse with an assistant to gather context, and automatically insert the generated answers into the template with live preview and export support.
+
+## Features
+
+- ✏️ Markdown editor with placeholder highlighting
+- 💬 Chat workspace integrated with the OpenAI API
+- 🧠 Automatic mapping between AI answers and template placeholders
+- 🪟 Live Markdown preview and editable placeholder list
+- 🔁 Regenerate answers and fine-tune values manually
+- 📥 Download the filled Markdown document
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment**
+
+   Create a `.env` file at the project root and provide your OpenAI API key:
+
+   ```bash
+   OPENAI_API_KEY=sk-...
+   ```
+
+3. **Run the development server**
+
+   ```bash
+   npm run dev
+   ```
+
+4. **Open the editor**
+
+   Visit [http://localhost:3000/editor](http://localhost:3000/editor) to start filling templates with AI assistance.
+
+## Project Structure
+
+- `pages/editor.vue` – main workspace combining the editor, placeholders, preview, and chat
+- `components/MarkdownEditor.vue` – markdown editor with placeholder highlighting
+- `components/ChatBox.vue` – chat interface for interacting with the AI
+- `components/PlaceholderList.vue` – editable list of detected placeholders
+- `components/PreviewPane.vue` – live rendered Markdown preview
+- `server/api/generate.post.ts` – Nuxt server route that calls the OpenAI API
+- `composables/useAI.ts` – composable for managing AI requests and state
+
+## Tailwind CSS
+
+Tailwind CSS is configured via `tailwind.config.ts` and `assets/css/tailwind.css`. Adjust the theme or add utilities as needed.
+
+## Example Template
+
+An example template is available at `assets/templates/example.md` and loads automatically when visiting the editor. Modify it or replace with your own template to detect new placeholders instantly.
+
+---
+
+Built with ❤️ using Nuxt 3, Tailwind CSS, and the OpenAI API.

--- a/app.vue
+++ b/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="min-h-screen">
+    <NuxtPage />
+  </div>
+</template>

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-950 text-slate-100;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.6);
+  border-radius: 9999px;
+}

--- a/assets/templates/example.md
+++ b/assets/templates/example.md
@@ -1,0 +1,20 @@
+# Project Brief: {{project_name}}
+
+## Overview
+{{project_overview}}
+
+## Target Audience
+- Primary: {{primary_audience}}
+- Secondary: {{secondary_audience}}
+
+## Key Features
+1. {{feature_one}}
+2. {{feature_two}}
+3. {{feature_three}}
+
+## Timeline
+- Kickoff: {{kickoff_date}}
+- Launch: {{launch_date}}
+
+## Call to Action
+{{call_to_action}}

--- a/components/ChatBox.vue
+++ b/components/ChatBox.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+
+type Role = 'user' | 'assistant' | 'system'
+
+export interface ChatMessage {
+  id: string
+  role: Role
+  content: string
+  createdAt: string
+}
+
+const props = defineProps<{
+  messages: ChatMessage[]
+  loading?: boolean
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'send', value: string): void
+  (e: 'regenerate'): void
+}>()
+
+const input = ref('')
+const containerRef = ref<HTMLDivElement | null>(null)
+
+const canSend = computed(() => input.value.trim().length > 0 && !props.loading && !props.disabled)
+
+const scrollToBottom = async () => {
+  await nextTick()
+  if (containerRef.value) {
+    containerRef.value.scrollTop = containerRef.value.scrollHeight
+  }
+}
+
+watch(
+  () => props.messages,
+  () => {
+    scrollToBottom()
+  },
+  { deep: true }
+)
+
+const handleSend = () => {
+  if (!canSend.value) return
+  emit('send', input.value.trim())
+  input.value = ''
+}
+
+const handleKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Enter' && !event.shiftKey) {
+    event.preventDefault()
+    handleSend()
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col h-full gap-3">
+    <header class="flex items-center justify-between gap-2">
+      <div>
+        <h2 class="text-lg font-semibold text-slate-100">Chat</h2>
+        <p class="text-sm text-slate-400">Ask the AI for context to fill in your template.</p>
+      </div>
+      <button
+        type="button"
+        class="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-1.5 text-sm text-slate-200 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+        :disabled="loading || !messages.length"
+        @click="emit('regenerate')"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992V4.356m0 0a9.173 9.173 0 10-3.022 6.769M8.977 14.652H3.985v4.992m0 0a9.173 9.173 0 103.022-6.769" />
+        </svg>
+        Regenerate Answer
+      </button>
+    </header>
+
+    <div
+      ref="containerRef"
+      class="flex-1 space-y-3 overflow-y-auto rounded-lg border border-slate-800 bg-slate-900/60 p-4"
+    >
+      <p v-if="!messages.length" class="text-sm text-slate-400">
+        Start the conversation to generate placeholder values.
+      </p>
+      <div
+        v-for="message in messages"
+        :key="message.id"
+        class="flex flex-col gap-1 rounded-lg border border-transparent bg-slate-800/60 p-3"
+        :class="{
+          'border-primary/40 bg-primary/10 text-slate-100': message.role === 'assistant',
+          'border-slate-700 bg-slate-900/60 text-slate-200': message.role === 'user'
+        }"
+      >
+        <div class="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+          <span>{{ message.role === 'assistant' ? 'Assistant' : 'You' }}</span>
+          <span>{{ new Date(message.createdAt).toLocaleTimeString() }}</span>
+        </div>
+        <p class="whitespace-pre-wrap text-sm leading-relaxed">{{ message.content }}</p>
+      </div>
+      <div v-if="loading" class="flex items-center gap-2 text-sm text-slate-400">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 animate-spin" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12a7.5 7.5 0 0 1 12.42-5.46m2.08 5.46a7.5 7.5 0 0 1-12.42 5.46" />
+        </svg>
+        Waiting for AI response...
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <label for="chat-input" class="text-xs uppercase tracking-wide text-slate-400">Your message</label>
+      <textarea
+        id="chat-input"
+        v-model="input"
+        class="min-h-[96px] resize-y rounded-lg border border-slate-800 bg-slate-900/70 p-3 text-sm text-slate-100 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-50"
+        placeholder="Describe what should go into the template placeholders..."
+        :disabled="disabled"
+        @keydown="handleKeydown"
+      />
+      <div class="flex justify-end">
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white transition hover:bg-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="!canSend"
+          @click="handleSend"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5l15-7.5-15-7.5v6.375l10.5 1.125-10.5 1.125z" />
+          </svg>
+          Send
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/MarkdownEditor.vue
+++ b/components/MarkdownEditor.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = defineProps<{
+  modelValue: string
+  placeholders: string[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+}>()
+
+const textareaRef = ref<HTMLTextAreaElement | null>(null)
+const overlayRef = ref<HTMLElement | null>(null)
+let cleanup: (() => void) | null = null
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const highlighted = computed(() => {
+  const base = escapeHtml(props.modelValue || '')
+  if (!props.placeholders?.length) {
+    return base
+  }
+
+  const pattern = props.placeholders
+    .map((ph) => ph.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')
+
+  if (!pattern) {
+    return base
+  }
+
+  const regex = new RegExp(`\\{\\{(${pattern})\\}\\}`, 'g')
+  return base.replace(regex, (_, name: string) => {
+    return `<span class="text-primary font-semibold">{{${name}}}</span>`
+  })
+})
+
+watch(
+  () => props.modelValue,
+  () => {
+    // keep overlay scroll aligned
+    requestAnimationFrame(() => {
+      if (!textareaRef.value || !overlayRef.value) return
+      overlayRef.value.scrollTop = textareaRef.value.scrollTop
+      overlayRef.value.scrollLeft = textareaRef.value.scrollLeft
+    })
+  }
+)
+
+onMounted(() => {
+  if (!textareaRef.value || !overlayRef.value) return
+  const sync = () => {
+    if (!textareaRef.value || !overlayRef.value) return
+    overlayRef.value.scrollTop = textareaRef.value.scrollTop
+    overlayRef.value.scrollLeft = textareaRef.value.scrollLeft
+  }
+  textareaRef.value.addEventListener('scroll', sync)
+  cleanup = () => {
+    textareaRef.value?.removeEventListener('scroll', sync)
+  }
+})
+
+onBeforeUnmount(() => {
+  cleanup?.()
+})
+
+const handleInput = (event: Event) => {
+  const target = event.target as HTMLTextAreaElement
+  emit('update:modelValue', target.value)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 h-full">
+    <header class="flex items-center justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-slate-100">Markdown Template</h2>
+        <p class="text-sm text-slate-400">Insert placeholders like <code>{{`{{placeholder}}`}}</code>.</p>
+      </div>
+    </header>
+    <div class="relative flex-1">
+      <pre
+        ref="overlayRef"
+        aria-hidden="true"
+        class="absolute inset-0 pointer-events-none whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-left bg-slate-950 text-slate-400 p-4 border border-slate-800 rounded-lg overflow-auto"
+        v-html="highlighted"
+      />
+      <textarea
+        ref="textareaRef"
+        :value="modelValue"
+        @input="handleInput"
+        spellcheck="false"
+        class="w-full h-full resize-none font-mono text-sm leading-relaxed text-slate-100 bg-transparent p-4 border border-slate-800 rounded-lg focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 overflow-auto"
+        placeholder="Write your markdown template here..."
+      />
+    </div>
+  </div>
+</template>

--- a/components/PlaceholderList.vue
+++ b/components/PlaceholderList.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+const props = defineProps<{
+  placeholders: Record<string, string>
+}>()
+
+const emit = defineEmits<{
+  (e: 'update', payload: { name: string; value: string }): void
+}>()
+
+const handleInput = (name: string, value: string) => {
+  emit('update', { name, value })
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 h-full">
+    <header>
+      <h2 class="text-lg font-semibold text-slate-100">Placeholders</h2>
+      <p class="text-sm text-slate-400">Edit generated values before exporting.</p>
+    </header>
+    <div class="flex-1 space-y-3 overflow-y-auto rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+      <p v-if="!Object.keys(placeholders).length" class="text-sm text-slate-400">
+        No placeholders detected. Add placeholders like <code>{{`{{name}}`}}</code> to the template.
+      </p>
+      <div
+        v-for="([name, value], index) in Object.entries(placeholders)"
+        :key="name"
+        class="rounded-lg border border-slate-800 bg-slate-950/40 p-3"
+      >
+        <label :for="`placeholder-${index}`" class="text-xs uppercase tracking-wide text-slate-400">{{ name }}</label>
+        <textarea
+          :id="`placeholder-${index}`"
+          :value="value"
+          @input="handleInput(name, ($event.target as HTMLTextAreaElement).value)"
+          class="mt-2 h-24 w-full resize-y rounded-lg border border-slate-800 bg-slate-950/70 p-3 text-sm text-slate-100 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/PreviewPane.vue
+++ b/components/PreviewPane.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { marked } from 'marked'
+import { onMounted, ref, watch } from 'vue'
+
+let dompurify: typeof import('dompurify') | null = null
+
+const props = defineProps<{
+  content: string
+}>()
+
+const html = ref('')
+
+const render = async () => {
+  const raw = marked.parse(props.content || '', { breaks: true })
+  if (process.client) {
+    if (!dompurify) {
+      dompurify = await import('dompurify')
+    }
+    const createDOMPurify = dompurify.default
+    const purifier = createDOMPurify(window)
+    html.value = purifier.sanitize(raw)
+  } else {
+    html.value = raw
+  }
+}
+
+watch(
+  () => props.content,
+  () => {
+    render()
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  render()
+})
+</script>
+
+<template>
+  <div class="flex h-full flex-col gap-3">
+    <header>
+      <h2 class="text-lg font-semibold text-slate-100">Live Preview</h2>
+      <p class="text-sm text-slate-400">Filled template rendered in real time.</p>
+    </header>
+    <div class="prose prose-invert max-w-none flex-1 overflow-y-auto rounded-lg border border-slate-800 bg-slate-900/60 p-6">
+      <div v-if="!content" class="text-sm text-slate-400">Start typing in the editor to see the preview.</div>
+      <div v-else v-html="html" class="prose prose-invert max-w-none"></div>
+    </div>
+  </div>
+</template>

--- a/composables/useAI.ts
+++ b/composables/useAI.ts
@@ -1,0 +1,48 @@
+import { ref } from 'vue'
+import type { ChatMessage } from '@/components/ChatBox.vue'
+
+interface GenerateOptions {
+  template: string
+  placeholders: Record<string, string>
+  messages: ChatMessage[]
+}
+
+interface GenerateResponse {
+  placeholders: Record<string, string>
+  assistantMessage: string
+}
+
+export const useAI = () => {
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const generate = async ({ template, placeholders, messages }: GenerateOptions): Promise<GenerateResponse | null> => {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await $fetch<GenerateResponse>('/api/generate', {
+        method: 'POST',
+        body: {
+          template,
+          placeholders,
+          messages
+        }
+      })
+      return response
+    } catch (err) {
+      console.error('AI generation failed', err)
+      error.value =
+        (err as { statusMessage?: string })?.statusMessage || 'Unable to contact the AI service. Please try again.'
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    loading,
+    error,
+    generate
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,0 +1,23 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  devtools: { enabled: false },
+  css: ['@/assets/css/tailwind.css'],
+  modules: [],
+  typescript: {
+    strict: true,
+    typeCheck: true
+  },
+  runtimeConfig: {
+    openaiApiKey: process.env.OPENAI_API_KEY,
+    public: {
+      // no public config required for now
+    }
+  },
+  postcss: {
+    plugins: {
+      tailwindcss: {},
+      autoprefixer: {}
+    }
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "chat-to-template",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "preview": "nuxt preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "dompurify": "^3.1.6",
+    "marked": "^12.0.2",
+    "nuxt": "^3.12.3",
+    "openai": "^4.57.0"
+  },
+  "devDependencies": {
+    "@types/dompurify": "^3.0.5",
+    "@types/marked": "^6.0.1",
+    "@tailwindcss/typography": "^0.5.15",
+    "@types/node": "^22.7.4",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.11.1",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-vue": "^9.26.0",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3"
+  }
+}

--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import MarkdownEditor from '@/components/MarkdownEditor.vue'
+import ChatBox, { type ChatMessage } from '@/components/ChatBox.vue'
+import PlaceholderList from '@/components/PlaceholderList.vue'
+import PreviewPane from '@/components/PreviewPane.vue'
+import exampleTemplate from '@/assets/templates/example.md?raw'
+import { useAI } from '@/composables/useAI'
+
+type PlaceholderRecord = Record<string, string>
+
+const template = ref<string>(exampleTemplate)
+const placeholderValues = ref<PlaceholderRecord>({})
+const chatMessages = ref<ChatMessage[]>([])
+const { loading, error, generate } = useAI()
+
+const placeholderNames = computed(() => {
+  const matches = template.value.match(/\{\{(.*?)\}\}/g) || []
+  const set = new Set<string>()
+  matches.forEach((match) => {
+    const name = match.replace(/\{\{|\}\}/g, '').trim()
+    if (name) set.add(name)
+  })
+  return Array.from(set)
+})
+
+watch(
+  placeholderNames,
+  (names) => {
+    const updated: PlaceholderRecord = {}
+    names.forEach((name) => {
+      updated[name] = placeholderValues.value[name] ?? ''
+    })
+    placeholderValues.value = updated
+  },
+  { immediate: true }
+)
+
+const filledMarkdown = computed(() => {
+  let output = template.value
+  for (const [key, value] of Object.entries(placeholderValues.value)) {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    output = output.replace(new RegExp(`\\{\\{${escaped}\\}\\}`, 'g'), value || '')
+  }
+  return output
+})
+
+const formatAssistantMessage = (placeholders: PlaceholderRecord) => {
+  if (!Object.keys(placeholders).length) {
+    return 'No placeholder values were generated.'
+  }
+  const lines = Object.entries(placeholders).map(([key, value]) => `{{${key}}}: ${value}`)
+  return lines.join('\n')
+}
+
+const createMessageId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `msg-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+const pushMessage = (role: ChatMessage['role'], content: string) => {
+  chatMessages.value.push({
+    id: createMessageId(),
+    role,
+    content,
+    createdAt: new Date().toISOString()
+  })
+}
+
+const requestAI = async () => {
+  const response = await generate({
+    template: template.value,
+    placeholders: placeholderValues.value,
+    messages: chatMessages.value
+  })
+
+  if (!response) return
+
+  const validKeys = new Set(placeholderNames.value)
+  Object.entries(response.placeholders).forEach(([key, value]) => {
+    if (validKeys.has(key)) {
+      placeholderValues.value[key] = value
+    }
+  })
+
+  pushMessage('assistant', response.assistantMessage || formatAssistantMessage(response.placeholders))
+}
+
+const handleSend = async (message: string) => {
+  pushMessage('user', message)
+  await requestAI()
+}
+
+const handleRegenerate = async () => {
+  if (!chatMessages.value.some((msg) => msg.role === 'user')) return
+  await requestAI()
+}
+
+const handlePlaceholderUpdate = ({ name, value }: { name: string; value: string }) => {
+  placeholderValues.value = {
+    ...placeholderValues.value,
+    [name]: value
+  }
+}
+
+const handleDownload = () => {
+  if (!process.client) return
+  const blob = new Blob([filledMarkdown.value], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = 'template.md'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+onMounted(() => {
+  if (!chatMessages.value.length) {
+    pushMessage(
+      'assistant',
+      'Welcome! Provide project details or questions, then press "Send" to generate values for the detected placeholders.'
+    )
+  }
+})
+</script>
+
+<template>
+  <div class="flex min-h-screen flex-col gap-6 p-6">
+    <header class="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+      <div class="flex flex-col gap-1">
+        <p class="text-sm font-medium uppercase tracking-[0.2em] text-primary">Markdown Template Editor</p>
+        <h1 class="text-3xl font-bold text-slate-50">Chat-to-Template Workspace</h1>
+        <p class="text-sm text-slate-400">
+          Build reusable Markdown documents. Ask questions in the chat and the AI will fill placeholder values automatically.
+        </p>
+      </div>
+      <div class="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="loading || !Object.keys(placeholderValues).length"
+          @click="handleDownload"
+        >
+          Download Markdown
+        </button>
+        <div v-if="error" class="rounded-lg border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+          {{ error }}
+        </div>
+      </div>
+    </header>
+
+    <main class="grid flex-1 grid-cols-1 gap-6 xl:grid-cols-3">
+      <section class="xl:col-span-2 flex flex-col gap-6">
+        <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <div class="h-[28rem] lg:h-[32rem] xl:h-[36rem]">
+            <MarkdownEditor v-model="template" :placeholders="placeholderNames" />
+          </div>
+          <div class="h-[28rem] lg:h-[32rem] xl:h-[36rem]">
+            <PlaceholderList :placeholders="placeholderValues" @update="handlePlaceholderUpdate" />
+          </div>
+        </div>
+        <div class="min-h-[20rem] rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
+          <PreviewPane :content="filledMarkdown" />
+        </div>
+      </section>
+      <aside class="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 xl:col-span-1">
+        <ChatBox
+          :messages="chatMessages"
+          :loading="loading"
+          :disabled="!placeholderNames.length"
+          @send="handleSend"
+          @regenerate="handleRegenerate"
+        />
+      </aside>
+    </main>
+  </div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const router = useRouter()
+
+if (process.client) {
+  router.replace('/editor')
+}
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-slate-950 text-slate-200">
+    Redirecting to editor...
+  </div>
+</template>

--- a/postcss.config.ts
+++ b/postcss.config.ts
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/server/api/generate.post.ts
+++ b/server/api/generate.post.ts
@@ -1,0 +1,92 @@
+import OpenAI from 'openai'
+
+interface BodyPayload {
+  template: string
+  placeholders: Record<string, string>
+  messages: Array<{
+    role: 'user' | 'assistant' | 'system'
+    content: string
+    createdAt: string
+  }>
+}
+
+const formatConversation = (messages: BodyPayload['messages']): string => {
+  if (!messages?.length) return 'No conversation provided.'
+  return messages
+    .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+    .join('\n')
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+  const apiKey = config.openaiApiKey
+
+  if (!apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Missing OpenAI API key. Set OPENAI_API_KEY in your environment.'
+    })
+  }
+
+  const body = await readBody<BodyPayload>(event)
+  if (!body?.template) {
+    throw createError({ statusCode: 400, statusMessage: 'Template is required.' })
+  }
+
+  const client = new OpenAI({ apiKey })
+
+  const prompt = `Fill the following placeholders based on the user input.\n` +
+    `Template:\n${body.template}\n` +
+    `Existing placeholder values (if any): ${JSON.stringify(body.placeholders)}\n` +
+    `User context: ${formatConversation(body.messages)}\n` +
+    `Return valid JSON with placeholder names as keys and filled values as strings.`
+
+  try {
+    const response = await client.responses.create({
+      model: 'gpt-4o-mini',
+      input: [
+        {
+          role: 'system',
+          content: `You are a helpful assistant that only responds with JSON objects mapping placeholder names to filled values. Do not include any additional commentary.`
+        },
+        {
+          role: 'user',
+          content: prompt
+        }
+      ],
+      response_format: { type: 'json_object' }
+    })
+
+    const textOutput = response.output_text ||
+      response.output
+        ?.flatMap((item) =>
+          item.type === 'message'
+            ? item.content
+                .filter((content) => content.type === 'output_text')
+                .map((content) => ('text' in content ? content.text : ''))
+            : []
+        )
+        .join('')
+
+    if (!textOutput) {
+      throw new Error('Empty response from OpenAI')
+    }
+
+    const parsed = JSON.parse(textOutput) as Record<string, string>
+
+    const assistantSummary = Object.entries(parsed)
+      .map(([key, value]) => `{{${key}}}: ${value}`)
+      .join('\n') || 'No placeholders were filled.'
+
+    return {
+      placeholders: parsed,
+      assistantMessage: assistantSummary
+    }
+  } catch (error) {
+    console.error('OpenAI request failed', error)
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Failed to generate placeholder values. Please try again.'
+    })
+  }
+})

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from 'tailwindcss'
+import typography from '@tailwindcss/typography'
+
+export default {
+  content: [
+    './components/**/*.{vue,js,ts}',
+    './layouts/**/*.vue',
+    './pages/**/*.vue',
+    './composables/**/*.{js,ts}',
+    './plugins/**/*.{js,ts}',
+    './app.{vue,js,ts}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#2563eb',
+          dark: '#1d4ed8'
+        }
+      }
+    }
+  },
+  plugins: [typography]
+} satisfies Config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- scaffold a Nuxt 3 project configured with Tailwind CSS, linting, and example assets for markdown templates
- build the markdown editor, placeholder list, preview pane, and chat box components backed by a composable that talks to the new OpenAI generate API route
- implement the `/editor` workspace, index redirect, and server route that fills template placeholders from OpenAI responses

## Testing
- `npm install` *(fails in the execution environment: 403 Forbidden fetching @types/dompurify)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a63029088322b4ab96ecf00f6d67